### PR TITLE
Remove build step in Workflow for deploy now

### DIFF
--- a/.github/workflows/deploy-now.yml
+++ b/.github/workflows/deploy-now.yml
@@ -18,22 +18,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: 'recursive'
-      - name: Setup Node.js 14.x
-        if: ${{ steps.project.outputs.deployment-enabled == 'true' }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-      - name: Prepare project environment
-        if: ${{ steps.project.outputs.deployment-enabled == 'true' }}
-        run: |
-          npm install --global yarn
-          yarn install --frozen-lockfile
-      - name: Build project
-        if: ${{ steps.project.outputs.deployment-enabled == 'true' }}
-        run: yarn build
-        env:
-          CI: true
-          SITE_URL: ${{ steps.project.outputs.site-url }}
       - name: Deploy build
         if: ${{ steps.project.outputs.deployment-enabled == 'true' }}
         uses: ionos-deploy-now/deploy-to-ionos-action@v1
@@ -41,7 +25,7 @@ jobs:
           service-host: api-eu.ionos.space
           api-key: ${{ secrets.IONOS_API_KEY }}
           remote-host: ${{ steps.project.outputs.remote-host }}
-          dist-folder: dist
+          dist-folder: ./
           project: ${{ secrets.IONOS_PROJECT_ID }}
           storage-quota: ${{ steps.project.outputs.storage-quota }}
           branch-id: ${{ steps.project.outputs.branch-id }}


### PR DESCRIPTION
This Project does not need a node build step in github actions because the project just needs to be copied